### PR TITLE
[FIX] Replace missing ANDROID_HOME env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ jobs:
         script: test
 
         # In some cases, you may need to provide
-        # Android licence agreement id
+        # Android license agreement id
         # You can find it on your own machine under
         # `$ANDROID_HOME/licenses/android-sdk-license`,
-        # and add the file content as a GitHub secret named `$ANDROID_LICENCE`.
-        android-licence: ${{ secrets.ANDROID_LICENCE }}
+        # and add the file content as a GitHub secret named `$ANDROID_LICENSE`.
+        android-license: ${{ secrets.ANDROID_LICENSE }}
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 if [ -n "$1" ]; then
-    mkdir -p $ANDROID_HOME/licenses
-    echo -e $1 >> $ANDROID_HOME/licenses/android-sdk-license
-    echo -e "\n--> Licences accepted\n"
+    mkdir -p /opt/licenses
+    echo -e $1 >> /opt/licenses/android-sdk-license
+    echo -e "\n--> Licenses accepted"
 fi
 
 echo -e "\n--> Running 'sh gradlew $2'\n"


### PR DESCRIPTION
The ANDROID_HOME environment variable doesn't seem to be present in the 
`fdroid/ci-images-client` docker image